### PR TITLE
Support XSLT 3.0 and other improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,4 +259,17 @@
             </plugin>
         </plugins>
     </reporting-->
+    
+    <repositories>
+        <!--
+            Restlet (XMLCalabash dependency) is not on Maven Central
+            (see https://github.com/restlet/restlet-framework-java/issues/481)
+        -->
+        <repository>
+            <id>restlet-repo</id>
+            <name>Public online Restlet repository</name>
+            <url>http://maven.restlet.org</url>
+        </repository>
+    </repositories>
+    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     
     <groupId>top.marchand.xml</groupId>
     <artifactId>xsl-doc</artifactId>
-    <version>1.7</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     
     <name>xsl-doc</name>
@@ -53,6 +53,11 @@
             <groupId>top.marchand.xml</groupId>
             <artifactId>gaulois-pipe</artifactId>
             <version>1.01.07</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xmlcalabash</groupId>
+            <artifactId>xmlcalabash</artifactId>
+            <version>1.1.20-98</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/catalog-to-xsl-doc.xpl
+++ b/src/main/resources/catalog-to-xsl-doc.xpl
@@ -1,0 +1,145 @@
+<p:declare-step version="1.0"
+            xmlns:p="http://www.w3.org/ns/xproc"
+            xmlns:cx="http://xmlcalabash.com/ns/extensions"
+            xmlns:catalog="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+            xmlns:xsldoc="top:marchand:xml:xsl:doc"
+            type="xsldoc:catalog-to-xsl-doc"
+            name="main"
+            exclude-inline-prefixes="#all">
+	
+	<p:input port="source" sequence="false"/>
+	<p:option name="projectName" required="true"/>
+	<p:option name="absoluteRootFolder" required="true"/>
+	<p:option name="outputFolder" required="true"/>
+	
+	<p:declare-step type="xsldoc:accumulate">
+		<p:input port="source"/>
+		<p:output port="result"/>
+		<p:option name="absoluteRootFolder" required="true"/>
+		<!--
+		    implemented in Java
+		-->
+	</p:declare-step>
+	
+	<p:declare-step type="xsldoc:generate-index">
+		<p:option name="projectName" required="true"/>
+		<p:option name="outputFolder" required="true"/>
+		<!--
+		    implemented in Java
+		-->
+	</p:declare-step>
+	
+	<p:for-each name="sources">
+		<p:iteration-source select="/*/catalog:uri">
+			<p:pipe step="main" port="source"/>
+		</p:iteration-source>
+		<p:choose>
+			<p:when test="/*[ends-with(@uri,'.xsl')]">
+				<p:load>
+					<p:with-option name="href" select="/*/resolve-uri(@uri,base-uri(.))"/>
+				</p:load>
+			</p:when>
+			<p:otherwise>
+				<p:identity>
+					<p:input port="source">
+						<p:empty/>
+					</p:input>
+				</p:identity>
+			</p:otherwise>
+		</p:choose>
+	</p:for-each>
+	
+	<p:for-each name="generate">
+		<p:xslt output-base-uri="file:/whatever">
+			<p:input port="stylesheet">
+				<p:document href="get-xfile-dependencies.xsl"/>
+			</p:input>
+			<p:with-param name="includeContent" select="'false'"/>
+		</p:xslt>
+		<p:xslt>
+			<p:input port="stylesheet">
+				<p:document href="getFileContent.xsl"/>
+			</p:input>
+			<p:with-param name="levelsToKeep" select="'0'"/>
+		</p:xslt>
+		<p:xslt>
+			<p:input port="stylesheet">
+				<p:document href="calculateRelativePaths.xsl"/>
+			</p:input>
+			<p:with-param name="absoluteRootFolder" select="$absoluteRootFolder"/>
+			<p:with-param name="levelsToKeep" select="'0'"/>
+		</p:xslt>
+		<p:xslt>
+			<p:input port="stylesheet">
+				<p:document href="calculateHtmlOutputFile.xsl"/>
+			</p:input>
+			<p:with-param name="outputFolder" select="$outputFolder"/>
+		</p:xslt>
+		<xsldoc:accumulate name="accumulate">
+			<p:with-option name="absoluteRootFolder" select="$absoluteRootFolder"/>
+		</xsldoc:accumulate>
+		<p:xslt>
+			<p:input port="source">
+				<p:pipe step="accumulate" port="result"/>
+			</p:input>
+			<p:input port="stylesheet">
+				<p:document href="prepareTOC.xsl"/>
+			</p:input>
+			<p:input port="parameters">
+				<p:empty/>
+			</p:input>
+		</p:xslt>
+		<p:xslt name="toc">
+			<p:input port="stylesheet">
+				<p:document href="makeTOC.xsl"/>
+			</p:input>
+			<p:input port="parameters">
+				<p:empty/>
+			</p:input>
+		</p:xslt>
+		<p:sink/>
+		<p:xslt name="doc">
+			<p:input port="source">
+				<p:pipe step="accumulate" port="result"/>
+			</p:input>
+			<p:input port="stylesheet">
+				<p:document href="makeDoc.xsl"/>
+			</p:input>
+			<p:input port="parameters">
+				<p:empty/>
+			</p:input>
+		</p:xslt>
+		<p:sink/>
+		<p:xslt name="index">
+			<p:input port="source">
+				<p:pipe step="accumulate" port="result"/>
+			</p:input>
+			<p:input port="stylesheet">
+				<p:document href="makeIndex.xsl"/>
+			</p:input>
+			<p:input port="parameters">
+				<p:empty/>
+			</p:input>
+		</p:xslt>
+		<p:sink/>
+		<p:identity>
+			<p:input port="source">
+				<p:pipe step="toc" port="secondary"/>
+				<p:pipe step="doc" port="secondary"/>
+				<p:pipe step="index" port="secondary"/>
+			</p:input>
+		</p:identity>
+	</p:for-each>
+	
+	<p:for-each>
+		<p:store method="xhtml">
+			<p:with-option name="href" select="p:base-uri()"/>
+		</p:store>
+	</p:for-each>
+	
+	<xsldoc:generate-index cx:depends-on="generate">
+		<p:with-option name="projectName" select="$projectName"/>
+		<p:with-option name="outputFolder" select="$outputFolder"/>
+	</xsldoc:generate-index>
+	
+</p:declare-step>

--- a/src/main/resources/catalog-to-xsl-doc.xpl
+++ b/src/main/resources/catalog-to-xsl-doc.xpl
@@ -73,6 +73,7 @@
 			</p:input>
 			<p:with-param name="absoluteRootFolder" select="$absoluteRootFolder"/>
 			<p:with-param name="levelsToKeep" select="'0'"/>
+			<p:with-param name="projectName" select="$projectName"/>
 		</p:xslt>
 		<p:xslt>
 			<p:input port="stylesheet">

--- a/src/main/resources/catalog-to-xsl-doc.xpl
+++ b/src/main/resources/catalog-to-xsl-doc.xpl
@@ -71,6 +71,14 @@
 		</p:xslt>
 		<p:xslt>
 			<p:input port="stylesheet">
+				<p:document href="exposeComponents.xsl"/>
+			</p:input>
+			<p:input port="parameters">
+				<p:empty/>
+			</p:input>
+		</p:xslt>
+		<p:xslt>
+			<p:input port="stylesheet">
 				<p:document href="calculateHtmlOutputFile.xsl"/>
 			</p:input>
 			<p:with-param name="outputFolder" select="$outputFolder"/>

--- a/src/main/resources/catalog-to-xsl-doc.xpl
+++ b/src/main/resources/catalog-to-xsl-doc.xpl
@@ -38,6 +38,11 @@
 				<p:load>
 					<p:with-option name="href" select="/*/resolve-uri(@uri,base-uri(.))"/>
 				</p:load>
+				<p:add-attribute match="/*" attribute-name="catalog-name">
+					<p:with-option name="attribute-value" select="/*/@name">
+						<p:pipe step="sources" port="current"/>
+					</p:with-option>
+				</p:add-attribute>
 			</p:when>
 			<p:otherwise>
 				<p:identity>

--- a/src/main/resources/config-calabash.xml
+++ b/src/main/resources/config-calabash.xml
@@ -1,0 +1,4 @@
+<xproc-config xmlns="http://xmlcalabash.com/ns/configuration" xmlns:xsldoc="top:marchand:xml:xsl:doc">
+  <implementation type="xsldoc:accumulate" class-name="top.marchand.xml.xsl.doc.AccumulatorStep$CalabashStep"/>
+  <implementation type="xsldoc:generate-index" class-name="top.marchand.xml.xsl.doc.AccumulatorStep$GenerateIndexStep"/>
+</xproc-config>

--- a/src/main/resources/xsl-doc_gp.xml
+++ b/src/main/resources/xsl-doc_gp.xml
@@ -16,6 +16,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         <xslt href="cp:/calculateRelativePaths.xsl">
             <param name="absoluteRootFolder" value="$[absoluteRootFolder]"/>
         </xslt>
+        <xslt href="cp:/exposeComponents.xsl"/>
         <xslt href="cp:/calculateHtmlOutputFile.xsl" id="outputPaths">
             <param name="outputFolder" value="$[outputFolder]"/>
         </xslt>

--- a/src/main/xsl/calculateHtmlOutputFile.xsl
+++ b/src/main/xsl/calculateHtmlOutputFile.xsl
@@ -28,7 +28,6 @@
             <xsl:apply-templates select="@*"/>
             <xsl:variable name="uri" as="xs:string" select="string-join(($outputFolderURI,@root-rel-uri),'/')" />
             <xsl:attribute name="htmlOutputUri" select="resolve-uri(local:getDocumentationFileURI($uri))"/>
-            <xsl:attribute name="indexOutputUri" select="resolve-uri(local:getIndexFileURI($uri))"/>
             <xsl:attribute name="welcomeOutputUri" select="resolve-uri(local:getWelcomeFileURI($uri))"/>
             <xsl:attribute name="tocOutputUri" select="resolve-uri(local:getTocFileUri($uri))"/>
             <xsl:apply-templates select="node()"/>

--- a/src/main/xsl/calculateRelativePaths.xsl
+++ b/src/main/xsl/calculateRelativePaths.xsl
@@ -22,6 +22,8 @@
     <!-- the root folder where all xsl sources are in the project -->
     <xsl:param name="absoluteRootFolder" as="xs:string" required="yes"/>
     <xsl:param name="levelsToKeep" as="xs:string"/>
+    <xsl:param name="projectName" as="xs:string"/>
+    
     <xsl:variable name="absoluteRootUri" as="xs:anyURI">
         <xsl:choose>
             <xsl:when test="starts-with($absoluteRootFolder,'file:/')">
@@ -43,7 +45,17 @@
     <xsl:template match="file">
         <xsl:copy>
             <xsl:apply-templates select="@*"/>
-            <xsl:attribute name="root-rel-uri" select="local:normalizeFilePath(local:getRelativePath($absoluteRootUri,@base-uri))"/>
+            <xsl:attribute name="root-rel-uri">
+                <xsl:choose>
+                    <xsl:when test="(@catalog-name,@package-name)[1][matches(.,'^http://www\.daisy\.org/')]">
+                        <xsl:sequence select="replace((@catalog-name,@package-name)[1],'^http://www\.daisy\.org/','org/daisy/')"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:sequence select="concat(replace($projectName,'[^a-zA-Z0-9\.-]','_'),
+                                                     '/',local:normalizeFilePath(local:getRelativePath($absoluteRootUri,@base-uri)))"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
             <xsl:variable name="decoupe" as="xs:string+" select="tokenize(@base-uri,'/')"/>
             <xsl:attribute name="index-label" select="string-join($decoupe[position() ge (count($decoupe)-$nLevelsToKeep)],'/')"/>
             <xsl:apply-templates select="*"/>

--- a/src/main/xsl/exposeComponents.xsl
+++ b/src/main/xsl/exposeComponents.xsl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                exclude-result-prefixes="xs">
+	
+	<xsl:import href="lib/identity.xsl"/>
+	<xsl:import href="lib/common.xsl"/>
+	
+	<xsl:template match="file">
+		<xsl:variable name="this" as="element()" select="."/>
+		<xsl:variable name="file" as="element(file)">
+			<xsl:copy>
+				<xsl:apply-templates select="@*|node()"/>
+			</xsl:copy>
+		</xsl:variable>
+		<xsl:choose>
+			<xsl:when test="@dependance-type=('xsl:import','xsl:include','xsl:use-package')">
+				<xsl:for-each select="$file/component">
+					<component id="{generate-id(.)}" idref="{@id}">
+						<xsl:sequence select="../@rel-uri|../@root-rel-uri|@type|@name|@match"/>
+						<xsl:choose>
+							<xsl:when test="../@dependance-type=('xsl:import','xsl:include')">
+								<xsl:call-template name="visibility">
+									<xsl:with-param name="type" select="@type"/>
+									<xsl:with-param name="name" select="@name"/>
+									<xsl:with-param name="declared-visibility" select="@visibility"/>
+									<xsl:with-param name="expose" select="document($this/parent::*/@base-uri)/*/xsl:expose"/>
+								</xsl:call-template>
+							</xsl:when>
+							<xsl:when test="@visibility=('public','final')">
+								<xsl:variable name="visibility" as="attribute(visibility)?">
+									<xsl:call-template name="visibility">
+										<xsl:with-param name="type" select="@type"/>
+										<xsl:with-param name="name" select="@name"/>
+										<xsl:with-param name="declared-visibility" select="()"/>
+										<xsl:with-param name="expose" select="document($this/parent::*/@base-uri)
+										                                      /*/xsl:use-package[@href=$this/@rel-uri]/xsl:accept"/>
+									</xsl:call-template>
+								</xsl:variable>
+								<xsl:choose>
+									<xsl:when test="$visibility">
+										<xsl:if test="not($visibility='hidden')">
+											<xsl:sequence select="$visibility"/>
+										</xsl:if>
+									</xsl:when>
+									<xsl:otherwise>
+										<xsl:attribute name="visibility" select="'private'"/>
+									</xsl:otherwise>
+								</xsl:choose>
+							</xsl:when>
+						</xsl:choose>
+					</component>
+				</xsl:for-each>
+			</xsl:when>
+			<xsl:when test="@dependance-type='first-doc'"/>
+		</xsl:choose>
+		<xsl:sequence select="$file"/>
+	</xsl:template>
+	
+</xsl:stylesheet>

--- a/src/main/xsl/get-xfile-dependencies.xsl
+++ b/src/main/xsl/get-xfile-dependencies.xsl
@@ -32,6 +32,7 @@
 			<xsl:if test="/xsl:package/@name">
 				<xsl:attribute name="package-name" select="/xsl:package/@name"/>
 			</xsl:if>
+			<xsl:sequence select="/*/@catalog-name"/>
 			<xsl:if test="not(empty($rel-uri))">
 				<xsl:attribute name="rel-uri" select="$rel-uri"/>
 			</xsl:if>

--- a/src/main/xsl/getFileContent.xsl
+++ b/src/main/xsl/getFileContent.xsl
@@ -20,7 +20,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
     <xsl:param name="levelsToKeep" as="xs:string"/>
     <xd:doc scope="stylesheet">
         <xd:desc>
-            <xd:p>This program extract from input files all (root+1) elements, and generates an ID for each</xd:p>
+            <xd:p>This program extract from input files all (root+1) components, and generates an ID for each</xd:p>
             <xd:p><xd:b>Created on:</xd:b> Jun 28, 2016</xd:p>
             <xd:p><xd:b>Author:</xd:b> Christophe Marchand - christophe@marchand.top</xd:p>
             <xd:p></xd:p>
@@ -56,7 +56,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         <xsl:param name="xsl-name" as="xs:string" tunnel="yes"/>
         <xsl:param name="base-uri" as="xs:string" tunnel="yes"/>
         <xsl:param name="rel-uri" as="xs:string?" tunnel="yes"/>
-        <element type="template" id="{generate-id(.)}" path="{idgen:getXPath(.)}">
+        <component type="template" id="{generate-id(.)}" path="{idgen:getXPath(.)}">
             <xsl:choose>
                 <xsl:when test="exists(@match)">
                     <xsl:attribute name="match" select="@match"/>
@@ -72,39 +72,20 @@ can obtain one at https://mozilla.org/MPL/2.0/.
             <xsl:if test="preceding-sibling::*[1][self::xd:doc][not(@scope='stylesheet')]">
                 <xsl:copy-of select="preceding-sibling::*[1][self::xd:doc]"/>
             </xsl:if>
-        </element>
+        </component>
     </xsl:template>
     
-    <!--xsl:template match="xsl:param">
-        <element type="parameter" id="{generate-id(.)}">
-            <xsl:copy-of select="local:extractName(@name)"/>
-            <xsl:apply-templates select="@* except @name"/>
-        </element>
-    </xsl:template>
-    
-    <xsl:template match="xsl:variable">
-        <element type="variable" id="{generate-id(.)}">
-            <xsl:copy-of select="local:extractName(@name)"/>
-            <xsl:apply-templates select="@* except @name"/>
-        </element>
-    </xsl:template-->
-    
-    <xsl:template match="xsl:function">
-        <element type="function" id="{generate-id(.)}">
-            <xsl:copy-of select="local:extractName(@name)"/>
-            <xsl:apply-templates select="@* except @name"/>
-            <xsl:copy-of select="local:calcSignature(.)"/>
-        </element>
-    </xsl:template>
-
-    <xsl:template match="xsl:accumulator | xs:attribute-set | 
-        xsl:character-map | xsl:decimal-format | xsl:import-schema | 
-        xsl:key | xsl:mode | xsl:namespace-alias | xsl:preserve-space | 
-        xsl:strip-space | xsl:param | xsl:variable">
-        <element type="{local-name(.)}" id="{generate-id(.)}" path="{idgen:getXPath(.)}">
+    <xsl:template match="xsl:accumulator | xs:attribute-set |
+        xsl:character-map | xsl:decimal-format | xsl:import-schema |
+        xsl:key | xsl:mode | xsl:namespace-alias | xsl:preserve-space |
+        xsl:strip-space | xsl:param | xsl:variable | xsl:function">
+        <component type="{local-name(.)}" id="{generate-id(.)}" path="{idgen:getXPath(.)}">
             <xsl:copy-of select="local:extractName((@name, @elements, @schema-location, @stylesheet-prefix, 'unnamed')[1])"/>    <!-- patch for strip-spaces -->
             <xsl:apply-templates select="@* except @name"/>
-        </element>
+            <xsl:if test="self::xsl:function">
+                <xsl:copy-of select="local:calcSignature(.)"/>
+            </xsl:if>
+        </component>
     </xsl:template>
 
     <!-- here, we don't care -->

--- a/src/main/xsl/getFileContent.xsl
+++ b/src/main/xsl/getFileContent.xsl
@@ -15,6 +15,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
     version="3.0">
 
     <xsl:import href="lib/identity.xsl"/>
+    <xsl:import href="lib/common.xsl"/>
     <xsl:import href="lib/id-generator.xsl"/>
     
     <xsl:param name="levelsToKeep" as="xs:string"/>
@@ -81,7 +82,8 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         xsl:strip-space | xsl:param | xsl:variable | xsl:function">
         <component type="{local-name(.)}" id="{generate-id(.)}" path="{idgen:getXPath(.)}">
             <xsl:copy-of select="local:extractName((@name, @elements, @schema-location, @stylesheet-prefix, 'unnamed')[1])"/>    <!-- patch for strip-spaces -->
-            <xsl:apply-templates select="@* except @name"/>
+            <xsl:apply-templates select="." mode="visibility"/>
+            <xsl:apply-templates select="@* except (@name|@visibility)"/>
             <xsl:if test="self::xsl:function">
                 <xsl:copy-of select="local:calcSignature(.)"/>
             </xsl:if>

--- a/src/main/xsl/lib/common.xsl
+++ b/src/main/xsl/lib/common.xsl
@@ -24,14 +24,10 @@
     </xd:doc>
     <xsl:function name="local:getDocumentationFileURI" as="xs:string">
         <xsl:param name="relUri" as="xs:string"/>
-        <xsl:variable name="relUriSeq" select="tokenize($relUri,'/')" as="xs:string*"/>
-        <xsl:variable name="sourceFileName" as="xs:string" select="$relUriSeq[last()]"/>
-        <xsl:variable name="intermediaryDirectory" as="xs:string" select="local:getIntermediaryDirectory($sourceFileName)"/>
-        <xsl:variable name="targetFileName" as="xs:string" select="concat(replace($sourceFileName, '\.','_'),'-doc.html')"/>
-        <xsl:variable name="ret" as="xs:string" select="string-join(($relUriSeq[position() &lt; last()],$intermediaryDirectory,$targetFileName),'/')"/>
-        <!--xsl:if test="$_debug">
+        <xsl:variable name="ret" as="xs:string" select="concat($relUri,'/doc.html')"/>
+        <xsl:if test="$_debug">
             <xsl:message select="concat('documentationFileUri -> ',$ret)"/>
-        </xsl:if-->
+        </xsl:if>
         <xsl:sequence select="$ret"/>
     </xsl:function>
     
@@ -42,10 +38,7 @@
     </xd:doc>
     <xsl:function name="local:getWelcomeFileURI" as="xs:string">
         <xsl:param name="relUri" as="xs:string"/>
-        <xsl:variable name="relUriSeq" select="tokenize($relUri,'/')" as="xs:string*"/>
-        <xsl:variable name="sourceFileName" as="xs:string" select="$relUriSeq[last()]"/>
-        <xsl:variable name="targetFileName" as="xs:string" select="concat(replace($sourceFileName, '\..*',''),'.html')"/>
-        <xsl:variable name="ret" as="xs:string" select="string-join(($relUriSeq[position() &lt; last()],$targetFileName),'/')"/>
+        <xsl:variable name="ret" as="xs:string" select="concat($relUri,'.html')"/>
         <xsl:if test="$_debug">
             <xsl:message select="concat('welcomeFileURI -> ',$ret)"/>
         </xsl:if>
@@ -59,33 +52,11 @@
     </xd:doc>
     <xsl:function name="local:getTocFileUri" as="xs:string">
         <xsl:param name="relUri" as="xs:string"/>
-        <xsl:variable name="relUriSeq" select="tokenize($relUri,'/')" as="xs:string*"/>
-        <xsl:variable name="sourceFileName" as="xs:string" select="$relUriSeq[last()]"/>
-        <xsl:variable name="intermediaryDirectory" as="xs:string" select="local:getIntermediaryDirectory($sourceFileName)"/>
-        <xsl:variable name="targetFileName" as="xs:string" select="concat(replace($sourceFileName, '\..*',''),'-toc.html')"/>
-        <xsl:variable name="ret" as="xs:string" select="string-join(($relUriSeq[position() &lt; last()],$intermediaryDirectory,$targetFileName),'/')"/>
+        <xsl:variable name="ret" as="xs:string" select="concat($relUri,'/toc.html')"/>
         <xsl:if test="$_debug">
             <xsl:message select="concat('tocFileUri -> ',$ret)"/>
         </xsl:if>
         <xsl:sequence select="$ret"/>
-    </xsl:function>
-    
-    <xd:doc>
-        <xd:desc>Returns the file name, without extension, preceded by an underscore</xd:desc>
-        <xd:param>The source file name</xd:param>
-        <xd:return>The intermediary directory name</xd:return>
-    </xd:doc>
-    <xsl:function name="local:getIntermediaryDirectory" as="xs:string">
-        <xsl:param name="sourceFileName" as="xs:string"/>
-        <xsl:choose>
-            <xsl:when test="contains($sourceFileName,'/')">
-                <xsl:sequence select="error(QName('top:marchand:xml:local','getIntermediaryDirectory_1'),'Q{top:marchand:xml:local}getIntermediaryDirectory(xs:string) does not accept qualified file names')"/>
-            </xsl:when>
-            <xsl:when test="contains($sourceFileName,'\\')">
-                <xsl:sequence select="error(QName('top:marchand:xml:local','getIntermediaryDirectory_2'),'Q{top:marchand:xml:local}getIntermediaryDirectory(xs:string) does not accept qualified file names')"/>
-            </xsl:when>
-        </xsl:choose>
-        <xsl:sequence select="concat('_',replace($sourceFileName, '\..*',''))"/>
     </xsl:function>
     
     <xd:doc>

--- a/src/main/xsl/lib/common.xsl
+++ b/src/main/xsl/lib/common.xsl
@@ -36,24 +36,6 @@
     </xsl:function>
     
     <xd:doc>
-        <xd:desc>Returns the relative URI of target HTML file</xd:desc>
-        <xd:param name="relUri">The XSL relative URI</xd:param>
-        <xd:return>The computed HTML file relative URI</xd:return>
-    </xd:doc>
-    <xsl:function name="local:getIndexFileURI" as="xs:string">
-        <xsl:param name="relUri" as="xs:string"/>
-        <xsl:variable name="relUriSeq" select="tokenize($relUri,'/')" as="xs:string*"/>
-        <xsl:variable name="sourceFileName" as="xs:string" select="$relUriSeq[last()]"/>
-        <xsl:variable name="intermediaryDirectory" as="xs:string" select="local:getIntermediaryDirectory($sourceFileName)"/>
-        <xsl:variable name="targetFileName" as="xs:string" select="concat(replace($sourceFileName, '\.','_'),'-index.html')"/>
-        <xsl:variable name="ret" as="xs:string" select="string-join(($relUriSeq[position() &lt; last()],$intermediaryDirectory,$targetFileName),'/')"/>
-        <xsl:if test="$_debug">
-            <xsl:message select="concat('indexFileURI -> ',$ret)"/>
-        </xsl:if>
-        <xsl:sequence select="$ret"/>
-    </xsl:function>
-    
-    <xd:doc>
         <xd:desc>Returns the relative URI of wecome HTML file</xd:desc>
         <xd:param name="relUri">The XSL relative URI</xd:param>
         <xd:return>The computed HTML file relative URI</xd:return>

--- a/src/main/xsl/makeDoc.xsl
+++ b/src/main/xsl/makeDoc.xsl
@@ -38,7 +38,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
             <xsl:variable name="xsl" select="document(@base-uri)"/>
             <html xmlns="http://www.w3.org/1999/xhtml">
                 <head>
-                    <title>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@package-name,@name)[1]"/></title>
+                    <title>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@catalog-name,@package-name,@name)[1]"/></title>
                     <base href="{string-join(for $i in 2 to count(tokenize(local:getDocumentationFileURI(@root-rel-uri),'/')) return '..','/')}"/>
                     <style type="text/css">
                         table{
@@ -75,7 +75,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
                     </style>
                 </head>
                 <body>
-                    <h2>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@package-name,@name)[1]"/></h2>
+                    <h2>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@catalog-name,@package-name,@name)[1]"/></h2>
                     <xsl:apply-templates select="$xsl//*[@scope='stylesheet']" mode="documentation"/>
                     <!--xsl:message><xsl:copy-of select="$xsl//*[@scope='stylesheet']"/></xsl:message-->
                     <xsl:apply-templates select="$xsl" mode="doc">

--- a/src/main/xsl/makeDoc.xsl
+++ b/src/main/xsl/makeDoc.xsl
@@ -103,16 +103,16 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         <xsl:choose>
             <xsl:when test="ancestor::xd:*"><xsl:next-match></xsl:next-match></xsl:when>
             <xsl:otherwise>
-                <xsl:variable name="element" as="element(element)">
+                <xsl:variable name="component" as="element(component)">
                     <xsl:choose>
                         <xsl:when test="self::xsl:function">
                             <xsl:variable name="signature" as="xs:string" select="idgen:calcSignature(.)"/>
-                            <xsl:sequence select="$file/element[@signature eq $signature]" />
+                            <xsl:sequence select="$file/component[@signature eq $signature]" />
                         </xsl:when>
-                        <xsl:otherwise><xsl:sequence select="$file/element[@path eq $path]"/></xsl:otherwise>
+                        <xsl:otherwise><xsl:sequence select="$file/component[@path eq $path]"/></xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
-                <!--xsl:if test="empty($element)">
+                <!--xsl:if test="empty($component)">
                     <xsl:text>Element est vide</xsl:text>
                 </xsl:if-->
                 <xsl:variable name="this" select="."/>
@@ -143,7 +143,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
                         </details>
                     </div>
                 </xsl:variable>
-                <xsl:apply-templates select="$element" mode="doc">
+                <xsl:apply-templates select="$component" mode="doc">
                     <xsl:with-param name="documentation" select="$documentation"/>
                     <xsl:with-param name="code" select="$code"/>
                 </xsl:apply-templates>
@@ -151,7 +151,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="element" mode="doc">
+    <xsl:template match="component" mode="doc">
         <xsl:param name="documentation" as="item()?"/>
         <xsl:param name="code" as="element()"/>
         <xsl:variable name="id" select="@id"/>
@@ -159,7 +159,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
         <div xmlns="http://www.w3.org/1999/xhtml" class="hideable">
             <details open="open" xmlns="http://www.w3.org/1999/xhtml">
                 <summary>
-                    <xsl:copy-of select="local:decodeTypeElement(@type)"/>
+                    <xsl:copy-of select="local:decodeTypeComponent(@type)"/>
                     <xsl:text> </xsl:text>
                     <xsl:value-of select="(@name, @match)[1]"/>
                     <xsl:if test="@mode">
@@ -201,7 +201,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
     
     <xsl:template match="text()" mode="doc"/>
 
-    <xsl:function name="local:decodeTypeElement">
+    <xsl:function name="local:decodeTypeComponent">
         <xsl:param name="type" as="xs:string"/>
         <xsl:variable name="ret" as="item()">
             <xsl:choose>
@@ -214,7 +214,7 @@ can obtain one at https://mozilla.org/MPL/2.0/.
                 </xsl:when>
                 <xsl:otherwise>
                     <span class="error" xmlns="http://www.w3.org/1999/xhtml">
-                        <xsl:value-of select="concat('Unknown element type: ',$type)"/>
+                        <xsl:value-of select="concat('Unknown component type: ',$type)"/>
                     </span>
                 </xsl:otherwise>
             </xsl:choose>

--- a/src/main/xsl/makeIndex.xsl
+++ b/src/main/xsl/makeIndex.xsl
@@ -21,6 +21,7 @@
             <html xmlns="http://www.w3.org/1999/xhtml">
                 <head>
                     <title>Documentation of <xsl:value-of select="@name"/></title>
+                    <base href="{string-join(for $i in 2 to count(tokenize(local:getWelcomeFileURI(@root-rel-uri),'/')) return '..','/')}"/>
                     <style type="text/css">
                         .niv1{
                         border: 1px solid black;
@@ -42,9 +43,8 @@
                     </style>
                 </head>
                     <frameset cols="25%,75%">
-                        <xsl:variable name="intermediaryDirectory" as="xs:string" select="local:getIntermediaryDirectory(@name)"/>
-                        <frame name="toc" src="{string-join(($intermediaryDirectory,tokenize(@tocOutputUri,'/')[last()]),'/')}"/>
-                        <frame name="doc" src="{string-join(($intermediaryDirectory,tokenize(@htmlOutputUri,'/')[last()]),'/')}"/>
+                        <frame name="toc" src="{local:getTocFileUri(@root-rel-uri)}"/>
+                        <frame name="doc" src="{local:getDocumentationFileURI(@root-rel-uri)}"/>
                     </frameset>
             </html>
         </xsl:result-document>

--- a/src/main/xsl/makeIndex.xsl
+++ b/src/main/xsl/makeIndex.xsl
@@ -20,7 +20,7 @@
         <xsl:result-document method="html" indent="yes" encoding="UTF-8" href="{@welcomeOutputUri}" doctype-public="-//W3C//DTD HTML 4.01 Frameset//EN http://www.w3.org/TR/html4/frameset.dtd">
             <html xmlns="http://www.w3.org/1999/xhtml">
                 <head>
-                    <title>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@package-name,@name)[1]"/></title>
+                    <title>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@catalog-name,@package-name,@name)[1]"/></title>
                     <base href="{string-join(for $i in 2 to count(tokenize(local:getWelcomeFileURI(@root-rel-uri),'/')) return '..','/')}"/>
                     <style type="text/css">
                         .niv1{

--- a/src/main/xsl/makeIndex.xsl
+++ b/src/main/xsl/makeIndex.xsl
@@ -20,7 +20,7 @@
         <xsl:result-document method="html" indent="yes" encoding="UTF-8" href="{@welcomeOutputUri}" doctype-public="-//W3C//DTD HTML 4.01 Frameset//EN http://www.w3.org/TR/html4/frameset.dtd">
             <html xmlns="http://www.w3.org/1999/xhtml">
                 <head>
-                    <title>Documentation of <xsl:value-of select="@name"/></title>
+                    <title>Documentation of <xsl:value-of select="@type"/><xsl:text> </xsl:text><xsl:value-of select="(@package-name,@name)[1]"/></title>
                     <base href="{string-join(for $i in 2 to count(tokenize(local:getWelcomeFileURI(@root-rel-uri),'/')) return '..','/')}"/>
                     <style type="text/css">
                         .niv1{

--- a/src/main/xsl/makeTOC.xsl
+++ b/src/main/xsl/makeTOC.xsl
@@ -26,7 +26,7 @@
             <html xmlns="http://www.w3.org/1999/xhtml">
                 <head>
                     <title>Table of Contents</title>
-                    <base href=".."/>
+                    <base href="{string-join(for $i in 2 to count(tokenize(local:getTocFileUri(@root-rel-uri),'/')) return '..','/')}"/>
                     <style type="text/css">
                         .niv1{
                         border: 1px solid black;
@@ -71,14 +71,13 @@
         <div class="niv2" xmlns="http://www.w3.org/1999/xhtml">
             <details>
                 <summary>
-                    <xsl:variable name="uri" as="xs:string" select="(element[1]/@relUri,@rel-uri)[1]"/>
                     <xsl:choose>
                         <xsl:when test="$type eq 'file'">
-                            <xsl:message>local:getDocumentationFileURI(<xsl:value-of select="$uri"/>)-&lt;<xsl:value-of select="local:getDocumentationFileURI($uri)"/></xsl:message>
+                            <xsl:message>local:getDocumentationFileURI(<xsl:value-of select="@rel-uri"/>)-&lt;<xsl:value-of select="local:getDocumentationFileURI(@rel-uri)"/></xsl:message>
                                 <xsl:message>
                                     <xsl:copy-of select="."/>
                                 </xsl:message>
-                            <a href="{local:getDocumentationFileURI($uri)}" target="doc"><xsl:value-of select="(@name[normalize-space()],concat('no ',../@label))[1]"/></a>                            
+                            <a href="{local:getDocumentationFileURI(@rel-uri)}" target="doc"><xsl:value-of select="@name"/></a>
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:value-of select="(@name[normalize-space()],concat('no ',../@label))[1]"/>

--- a/src/main/xsl/makeTOC.xsl
+++ b/src/main/xsl/makeTOC.xsl
@@ -68,31 +68,46 @@
     
     <xsl:template match="group">
         <xsl:param name="type" as="xs:string"/>
-        <div class="niv2" xmlns="http://www.w3.org/1999/xhtml">
-            <details>
-                <summary>
-                    <xsl:choose>
-                        <xsl:when test="$type eq 'file'">
-                            <xsl:message>local:getDocumentationFileURI(<xsl:value-of select="@rel-uri"/>)-&lt;<xsl:value-of select="local:getDocumentationFileURI(@rel-uri)"/></xsl:message>
+        <xsl:variable name="visible-components" as="element()*">
+            <xsl:apply-templates />
+        </xsl:variable>
+        <xsl:if test="exists($visible-components)">
+            <div class="niv2" xmlns="http://www.w3.org/1999/xhtml">
+                <details>
+                    <summary>
+                        <xsl:choose>
+                            <xsl:when test="$type eq 'file'">
+                                <xsl:message>local:getDocumentationFileURI(<xsl:value-of select="@root-rel-uri"/>)-&lt;<xsl:value-of select="local:getDocumentationFileURI(@root-rel-uri)"/></xsl:message>
                                 <xsl:message>
                                     <xsl:copy-of select="."/>
                                 </xsl:message>
-                            <a href="{local:getDocumentationFileURI(@rel-uri)}" target="doc"><xsl:value-of select="@name"/></a>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="(@name[normalize-space()],concat('no ',../@label))[1]"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </summary>
-                <ul><xsl:apply-templates /></ul>
-            </details>
-        </div>
+                                <a href="{local:getDocumentationFileURI(@root-rel-uri)}" target="doc"><xsl:value-of select="@name"/></a>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="(@name[normalize-space()],concat('no ',../@label))[1]"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </summary>
+                    <ul>
+                        <xsl:sequence select="$visible-components"/>
+                    </ul>
+                </details>
+            </div>
+        </xsl:if>
     </xsl:template>
     
     <xsl:template match="component">
-        <li xmlns="http://www.w3.org/1999/xhtml">
-            <a href="{local:getDocumentationFileURI(@relUri)}#{@id}" target="doc"><xsl:value-of select="(@name,@match)[1]"/></a>
-        </li>
+        <xsl:variable name="visibility" select="(@visibility,'private')[1]"/>
+        <xsl:variable name="visibility-when-used"
+                      select="if (/data/@type='package')
+                              then if ($visibility=('public','final'))
+                                   then 'private' else 'hidden'
+                              else $visibility"/>
+        <xsl:if test="not($visibility-when-used='hidden')">
+            <li xmlns="http://www.w3.org/1999/xhtml">
+                <a href="{local:getDocumentationFileURI(/data/@root-rel-uri)}#{@id}" target="doc"><xsl:value-of select="(@name,@match)[1]"/></a>
+            </li>
+        </xsl:if>
     </xsl:template>
     
 </xsl:stylesheet>

--- a/src/main/xsl/makeTOC.xsl
+++ b/src/main/xsl/makeTOC.xsl
@@ -89,7 +89,7 @@
         </div>
     </xsl:template>
     
-    <xsl:template match="element">
+    <xsl:template match="component">
         <li xmlns="http://www.w3.org/1999/xhtml">
             <a href="{local:getDocumentationFileURI(@relUri)}#{@id}" target="doc"><xsl:value-of select="(@name,@match)[1]"/></a>
         </li>

--- a/src/main/xsl/makeTOC.xsl
+++ b/src/main/xsl/makeTOC.xsl
@@ -55,15 +55,20 @@
     </xsl:template>
     
     <xsl:template match="*[starts-with(local-name(), 'by-')]">
-        <div class="niv1" xmlns="http://www.w3.org/1999/xhtml">
-            <details open="open">
-                <xsl:variable name="type" as="xs:string" select="substring(local-name(),4)"/>
-                <summary>Content by <xsl:value-of select="$type"/></summary>
-                <xsl:apply-templates >
-                    <xsl:with-param name="type" select="$type"/>
-                </xsl:apply-templates>
-            </details>
-        </div>
+        <xsl:variable name="type" as="xs:string" select="substring(local-name(),4)"/>
+        <xsl:variable name="non-empty-groups" as="element()*">
+            <xsl:apply-templates>
+                <xsl:with-param name="type" select="$type"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:if test="exists($non-empty-groups)">
+            <div class="niv1" xmlns="http://www.w3.org/1999/xhtml">
+                <details open="open">
+                    <summary>Content by <xsl:value-of select="$type"/></summary>
+                    <xsl:sequence select="$non-empty-groups"/>
+                </details>
+            </div>
+        </xsl:if>
     </xsl:template>
     
     <xsl:template match="group">

--- a/src/main/xsl/prepareTOC.xsl
+++ b/src/main/xsl/prepareTOC.xsl
@@ -14,7 +14,7 @@
     </xd:doc>
     
     <xsl:template match="/">
-        <data tocOutputUri="{file/@tocOutputUri}">
+        <data tocOutputUri="{file/@tocOutputUri}" root-rel-uri="{file/@root-rel-uri}">
             <by-file label="file">
                 <xsl:apply-templates select="file" mode="by-file"/>
             </by-file>

--- a/src/main/xsl/prepareTOC.xsl
+++ b/src/main/xsl/prepareTOC.xsl
@@ -19,7 +19,7 @@
                 <xsl:apply-templates select="file" mode="by-file"/>
             </by-file>
             <by-type label="type">
-                <xsl:for-each-group select=".//element" group-by="@type">
+                <xsl:for-each-group select=".//component" group-by="@type">
                     <group name="{current-grouping-key()}">
                         <xsl:apply-templates select="current-group()" mode="grouping">
                             <xsl:with-param name="groupName" select="current-grouping-key()"/>
@@ -28,7 +28,7 @@
                 </xsl:for-each-group>
             </by-type>
             <by-namespace label="namespace">
-                <xsl:for-each-group select=".//element" group-by="@namespace">
+                <xsl:for-each-group select=".//component" group-by="@namespace">
                     <group name="{current-grouping-key()}">
                         <xsl:apply-templates select="current-group()" mode="grouping">
                             <xsl:with-param name="groupName" select="current-grouping-key()"/>
@@ -37,7 +37,7 @@
                 </xsl:for-each-group>
             </by-namespace>
             <by-mode label="mode">
-                <xsl:for-each-group select=".//element[@type='template']" group-by="(@mode,'')[1]">
+                <xsl:for-each-group select=".//component[@type='template']" group-by="(@mode,'')[1]">
                     <group name="{current-grouping-key()}">
                         <xsl:apply-templates select="current-group()" mode="grouping">
                             <xsl:with-param name="groupName" select="current-grouping-key()"/>
@@ -52,21 +52,21 @@
         <xsl:variable name="relUri" select="@root-rel-uri"/>
         <xsl:variable name="absUri" select="@base-uri"/>
         <group name="{$relUri}" rel-uri="{$relUri}" base-uri="{$absUri}">
-            <xsl:apply-templates select="element" mode="by-file">
+            <xsl:apply-templates select="component" mode="by-file">
                 <xsl:with-param name="relUri" select="$relUri"/>
             </xsl:apply-templates>
         </group>
         <xsl:apply-templates select="file" mode="#current"/>
     </xsl:template>
     
-    <xsl:template match="element" mode="by-file">
+    <xsl:template match="component" mode="by-file">
         <xsl:param name="relUri" as="xs:string"/>
         <xsl:copy>
             <xsl:attribute name="relUri" select="$relUri"/>
             <xsl:apply-templates select="@*" mode="#default"/>
         </xsl:copy>
     </xsl:template>
-    <xsl:template match="element" mode="grouping">
+    <xsl:template match="component" mode="grouping">
         <xsl:param name="groupName" as="xs:string"/>
         <xsl:copy>
             <xsl:attribute name="relUri" select="../@root-rel-uri"/>

--- a/src/main/xsl/prepareTOC.xsl
+++ b/src/main/xsl/prepareTOC.xsl
@@ -13,69 +13,40 @@
         </xd:desc>
     </xd:doc>
     
-    <xsl:template match="/">
-        <data tocOutputUri="{file/@tocOutputUri}" root-rel-uri="{file/@root-rel-uri}">
+    <xsl:template match="/file">
+        <data>
+            <xsl:sequence select="@tocOutputUri|@root-rel-uri|@type"/>
             <by-file label="file">
-                <xsl:apply-templates select="file" mode="by-file"/>
+                <xsl:for-each-group select="component" group-by="(@rel-uri,/file/@rel-uri)[1]">
+                    <group name="{current-grouping-key()}">
+                        <xsl:sequence select="(current-group()[1]/@rel-uri,/file/@rel-uri)[1]"/>
+                        <xsl:sequence select="(current-group()[1]/@root-rel-uri,/file/@root-rel-uri)[1]"/>
+                        <xsl:sequence select="current-group()"/>
+                    </group>
+                </xsl:for-each-group>
             </by-file>
             <by-type label="type">
-                <xsl:for-each-group select=".//component" group-by="@type">
+                <xsl:for-each-group select="component" group-by="@type">
                     <group name="{current-grouping-key()}">
-                        <xsl:apply-templates select="current-group()" mode="grouping">
-                            <xsl:with-param name="groupName" select="current-grouping-key()"/>
-                        </xsl:apply-templates>
+                        <xsl:sequence select="current-group()"/>
                     </group>
                 </xsl:for-each-group>
             </by-type>
             <by-namespace label="namespace">
-                <xsl:for-each-group select=".//component" group-by="@namespace">
+                <xsl:for-each-group select="component" group-by="@namespace">
                     <group name="{current-grouping-key()}">
-                        <xsl:apply-templates select="current-group()" mode="grouping">
-                            <xsl:with-param name="groupName" select="current-grouping-key()"/>
-                        </xsl:apply-templates>
+                        <xsl:sequence select="current-group()"/>
                     </group>
                 </xsl:for-each-group>
             </by-namespace>
             <by-mode label="mode">
-                <xsl:for-each-group select=".//component[@type='template']" group-by="(@mode,'')[1]">
+                <xsl:for-each-group select="component[@type='template']" group-by="(@mode,'')[1]">
                     <group name="{current-grouping-key()}">
-                        <xsl:apply-templates select="current-group()" mode="grouping">
-                            <xsl:with-param name="groupName" select="current-grouping-key()"/>
-                        </xsl:apply-templates>
+                        <xsl:sequence select="current-group()"/>
                     </group>
                 </xsl:for-each-group>
             </by-mode>
         </data>
-    </xsl:template>
-    
-    <xsl:template match="file" mode="by-file">
-        <xsl:variable name="relUri" select="@root-rel-uri"/>
-        <xsl:variable name="absUri" select="@base-uri"/>
-        <group name="{$relUri}" rel-uri="{$relUri}" base-uri="{$absUri}">
-            <xsl:apply-templates select="component" mode="by-file">
-                <xsl:with-param name="relUri" select="$relUri"/>
-            </xsl:apply-templates>
-        </group>
-        <xsl:apply-templates select="file" mode="#current"/>
-    </xsl:template>
-    
-    <xsl:template match="component" mode="by-file">
-        <xsl:param name="relUri" as="xs:string"/>
-        <xsl:copy>
-            <xsl:attribute name="relUri" select="$relUri"/>
-            <xsl:apply-templates select="@*" mode="#default"/>
-        </xsl:copy>
-    </xsl:template>
-    <xsl:template match="component" mode="grouping">
-        <xsl:param name="groupName" as="xs:string"/>
-        <xsl:copy>
-            <xsl:attribute name="relUri" select="../@root-rel-uri"/>
-            <xsl:apply-templates select="@*" mode="#default"/>
-        </xsl:copy>
-    </xsl:template>
-    
-    <xsl:template match="@*" mode="#default">
-        <xsl:copy-of select="."/>
     </xsl:template>
     
 </xsl:stylesheet>

--- a/src/test/xspec/calculateRelativePaths.xspec
+++ b/src/test/xspec/calculateRelativePaths.xspec
@@ -3,6 +3,7 @@
     stylesheet="../../main/xsl/calculateRelativePaths.xsl" xslt-version="3.0">
     <x:param name="absoluteRootFolder" select="'file:/home/cmarchand/'"/>
     <x:param name="levelsToKeep" select="'0'"/>
+    <x:param name="projectName" select="'test-project'"/>
     
     <x:scenario label="Scenario for testing template match @base-uri">
         <x:context>

--- a/src/test/xspec/common.xspec
+++ b/src/test/xspec/common.xspec
@@ -31,27 +31,6 @@
         <x:expect label="Not yet implemented" select="'Not yet implemented'"/>
     </x:scenario>
 
-    <x:scenario label="Scenario for testing function getIntermediaryDirectory">
-        <x:scenario label="local filename">
-            <x:call function="local:getIntermediaryDirectory">
-                <x:param name="sourceFileName" select="'toto.xsl'"/>
-            </x:call>
-            <x:expect label="_toto" select="'_toto'"/>
-        </x:scenario>
-        <x:scenario label="qualifed linux filename" pending="Not yet implemented in XSpec">
-            <x:call function="local:getIntermediaryDirectory">
-                <x:param name="sourceFileName" select="'src/main/xsl/toto.xsl'"/>
-            </x:call>
-            <x:expect label="src/main/xsl/_toto" select="'src/main/xsl/_toto'"/>
-        </x:scenario>
-        <x:scenario label="qualifed windows filename" pending="Not yet implemented in XSpec">
-            <x:call function="local:getIntermediaryDirectory">
-                <x:param name="sourceFileName" select="'src\main\xsl\toto.xsl'"/>
-            </x:call>
-            <x:expect label="src\main\xsl\_toto" select="'src\main\xsl\_toto'"/>
-        </x:scenario>
-    </x:scenario>
-
     <x:scenario pending="Not yet implemented"
         label="Scenario for testing function normalizeFilePath">
         <x:call function="local:normalizeFilePath">

--- a/src/test/xspec/getFileContent.xspec
+++ b/src/test/xspec/getFileContent.xspec
@@ -15,11 +15,11 @@
             <file dependance-type="first-doc"
                 name="premier.xsl"
                 base-uri="../../test/resources/premier.xsl" levelsToKeep="0">
-                <element 
+                <component 
                     type="template" 
                     id="..." 
                     path="..."
-                    match="/"></element>
+                    match="/"></component>
             </file>
         </x:expect>
     </x:scenario>
@@ -51,8 +51,8 @@
                 <x:param name="rel-uri" select="'no_value'" tunnel="yes"/>
                 <xsl:template match="/"/>
             </x:context>
-            <x:expect label="element type template" >
-                <element type="template" match="/" id="..." path="..."/>
+            <x:expect label="component type template" >
+                <component type="template" match="/" id="..." path="..."/>
             </x:expect>
         </x:scenario>
         <x:scenario label="with doc">
@@ -65,12 +65,12 @@
                 </xd:doc>
                 <xsl:template match="/"/>
             </x:context>
-            <x:expect label="element type template" >
-                <element type="template" match="/" id="..." path="...">
+            <x:expect label="component type template" >
+                <component type="template" match="/" id="..." path="...">
                     <xd:doc>
                         <xd:desc><xd:p>This is the documentation</xd:p></xd:desc>
                     </xd:doc>
-                </element>
+                </component>
             </x:expect>
         </x:scenario>
     </x:scenario>
@@ -88,8 +88,8 @@
         <x:context>
             <xsl:param name="p" as="xs:string"/>
         </x:context>
-        <x:expect label="element type param">
-            <element type="param" name="p" id="..." as="xs:string" namespace="" path="..."/>
+        <x:expect label="component type param">
+            <component type="param" name="p" id="..." as="xs:string" namespace="" path="..."/>
         </x:expect>
     </x:scenario>
 
@@ -97,8 +97,8 @@
         <x:context>
             <xsl:variable name="v" as="xs:string" select="'toto'"/>
         </x:context>
-        <x:expect label="element type variable">
-            <element type="variable" name="v" id="..." as="xs:string" namespace="" select="'toto'" path="..."/>
+        <x:expect label="component type variable">
+            <component type="variable" name="v" id="..." as="xs:string" namespace="" select="'toto'" path="..."/>
         </x:expect>
     </x:scenario>
 
@@ -110,8 +110,8 @@
                 <xsl:param name="p3"/>
             </xsl:function>
         </x:context>
-        <x:expect label="element type function">
-            <element type="function" id="..." namespace="top:marchand:xml:local" name="myFunction" as="xs:string" signature="Q{{top:marchand:xml:local}}myFunction(xs:string,xs:integer*,item())"/>
+        <x:expect label="component type function">
+            <component type="function" id="..." path="/Q{{http://www.w3.org/1999/XSL/Transform}}function[1]" namespace="top:marchand:xml:local" name="myFunction" as="xs:string" signature="Q{{top:marchand:xml:local}}myFunction(xs:string,xs:integer*,item())"/>
         </x:expect>
     </x:scenario>
 
@@ -120,7 +120,7 @@
             <xsl:strip-space elements="#all"/>
         </x:context>
         <x:expect label="a not null name">
-            <element type="strip-space" id="..." path="..." name="#all" elements="#all"/>
+            <component type="strip-space" id="..." path="..." name="#all" elements="#all"/>
         </x:expect>
     </x:scenario>
 
@@ -129,7 +129,7 @@
             <xsl:preserve-space elements="#all"/>
         </x:context>
         <x:expect label="a not null name">
-            <element type="preserve-space" id="..." path="..." name="#all" elements="#all"/>
+            <component type="preserve-space" id="..." path="..." name="#all" elements="#all"/>
         </x:expect>
     </x:scenario>
 </x:description>

--- a/src/test/xspec/getFileContent.xspec
+++ b/src/test/xspec/getFileContent.xspec
@@ -89,7 +89,7 @@
             <xsl:param name="p" as="xs:string"/>
         </x:context>
         <x:expect label="component type param">
-            <component type="param" name="p" id="..." as="xs:string" namespace="" path="..."/>
+            <component type="param" name="p" id="..." as="xs:string" namespace="" path="..." visibility="public"/>
         </x:expect>
     </x:scenario>
 

--- a/src/test/xspec/lib/common.xspec
+++ b/src/test/xspec/lib/common.xspec
@@ -8,13 +8,13 @@
             <x:call function="local:getDocumentationFileURI">
                 <x:param name="relUri" select="'test.xsl'"/>
             </x:call>
-            <x:expect label="_test/test_xsl-doc.html" select="'_test/test_xsl-doc.html'"/>
+            <x:expect label="_test/test_xsl-doc.html" select="'test.xsl/doc.html'"/>
         </x:scenario>
         <x:scenario label="Relative path">
             <x:call function="local:getDocumentationFileURI">
                 <x:param name="relUri" select="'../overthere/test.xsl'"/>
             </x:call>
-            <x:expect label="../overthere/_test/test_xsl-doc.html" select="'../overthere/_test/test_xsl-doc.html'"/>
+            <x:expect label="../overthere/_test/test_xsl-doc.html" select="'../overthere/test.xsl/doc.html'"/>
         </x:scenario>
     </x:scenario>
     <x:scenario label="Scenario for testing local:getTocFileUri">
@@ -22,13 +22,13 @@
             <x:call function="local:getTocFileUri">
                 <x:param name="relUri" select="'test.xsl'"/>
             </x:call>
-            <x:expect label="_test/test-toc.html" select="'_test/test-toc.html'"/>
+            <x:expect label="_test/test-toc.html" select="'test.xsl/toc.html'"/>
         </x:scenario>
         <x:scenario label="Relative path">
             <x:call function="local:getTocFileUri">
                 <x:param name="relUri" select="'../overthere/test.xsl'"/>
             </x:call>
-            <x:expect label="../overthere/_test/test-toc.html" select="'../overthere/_test/test-toc.html'"/>
+            <x:expect label="../overthere/_test/test-toc.html" select="'../overthere/test.xsl/toc.html'"/>
         </x:scenario>
     </x:scenario>
     <x:scenario label="Scenario for testing function removeSingleDot">


### PR DESCRIPTION
These are some changes I did in order to make the plugin meet our requirements. The main change is the support for XSLT 3.0, which makes it possible to control the visibility of XSLT components, which we need in order to be able to define the public API of our modules.

I still have a list of things that can be improved:
- support for visibility="abstract" and xsl:override
- handle space separated list in mode attribute of xsl:template
- take into account visibility of xsl:mode elements
- when processing xsl:expose, compare component names as EQName instead of strings
- when processing xsl:expose, handle NamedFunctionRef names
- when processing xsl:expose, handle Q{uri}* names
- ...

You can disregard the last commit which is specific to DAISY Pipeline.